### PR TITLE
Add PyPI publishing workflow and version bumping command

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: 2026 University of Strasbourg
+# SPDX-FileContributor: Christophe Prud'homme
+# SPDX-FileContributor: Cemosis
+# SPDX-License-Identifier: Apache-2.0
+
+name: Publish PyPI
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "SemVer tag to publish (vMAJOR.MINOR.PATCH)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  validate-release:
+    name: Validate release tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Enforce official Feel++ repository
+        run: |
+          if [ "${GITHUB_REPOSITORY}" != "feelpp/kub-cli" ]; then
+            echo "Publishing is only allowed from feelpp/kub-cli."
+            exit 2
+          fi
+
+      - name: Validate SemVer and pyproject version
+        run: |
+          TAG_VALUE="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
+          python scripts/validate_release_tag.py --tag "${TAG_VALUE}"
+
+  build-distributions:
+    name: Build sdist and wheel
+    needs: validate-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Validate distributions
+        run: twine check dist/*
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+          if-no-files-found: error
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build-distributions
+    if: github.repository == 'feelpp/kub-cli'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    environment:
+      name: pypi
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ SPDX-License-Identifier: Apache-2.0
 
 # Changelog
 
+## Unreleased
+
+- Added `kub-cli bump` command for SemVer version updates in `pyproject.toml` and fallback package version
+- Added GitHub Actions workflow for PyPI publishing via GitHub environment `pypi`
+- Added release validation script enforcing `vMAJOR.MINOR.PATCH` tags and tag/version matching
+- Restricted publish workflow to official `feelpp/kub-cli` repository and documented PyPI organization target `feelpp`
+
 ## 0.1.0 - 2026-03-14
 
 - Initial production-ready release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,3 +34,10 @@ Avoid reimplementing business logic that belongs in `kub-dataset`, `kub-simulate
 - include tests for behavior changes
 - update README when user-facing behavior changes
 - keep dependencies minimal
+
+## Releases
+
+- Use SemVer (`MAJOR.MINOR.PATCH`) for `project.version`.
+- Use matching Git tag format `vMAJOR.MINOR.PATCH`.
+- PyPI publishing is handled by `.github/workflows/publish-pypi.yml` using GitHub environment `pypi`.
+- Official publish source is `feelpp/kub-cli` and target PyPI org is `feelpp`.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Derived Apptainer remote source:
 
 ```text
 oras://ghcr.io/feelpp/ktirio-urban-building:master-sif
+```
 
 Default image references used when no explicit image is configured:
 
@@ -143,7 +144,6 @@ Other tags are supported (for example `pr-<nnn>`), e.g.:
 
 - Docker: `ghcr.io/feelpp/ktirio-urban-building:pr-456`
 - Apptainer source: `oras://ghcr.io/feelpp/ktirio-urban-building:pr-456-sif`
-```
 
 Important:
 
@@ -250,6 +250,59 @@ uv venv .venv
 uv pip install -e '.[dev]'
 pytest
 ```
+
+Version bumping for maintainers:
+
+```bash
+# bump patch/minor/major from pyproject version
+kub-cli bump patch
+kub-cli bump minor
+kub-cli bump major
+
+# explicit target version
+kub-cli bump patch --to 0.2.0
+
+# preview only
+kub-cli bump patch --dry-run
+```
+
+Release versioning policy:
+
+- `kub-cli` uses SemVer (`MAJOR.MINOR.PATCH`).
+- Release tags must be `vMAJOR.MINOR.PATCH`.
+- The tag version must match `project.version` in `pyproject.toml`.
+
+PyPI publishing via GitHub environment:
+
+- Workflow: `.github/workflows/publish-pypi.yml`
+- Trigger: push a SemVer tag (for example `v0.2.0`) or run `workflow_dispatch`.
+- Publish job uses GitHub `environment: pypi` and OpenID Connect trusted publishing (no PyPI API token needed in GitHub secrets).
+- Publishing is restricted to the official repository `feelpp/kub-cli`.
+
+One-time setup:
+
+1. In GitHub repository settings, create environment `pypi`.
+2. In PyPI Organizations, ensure project `kub-cli` belongs to organization `feelpp`.
+3. In the `kub-cli` PyPI project settings (under organization `feelpp`), add a trusted publisher bound to:
+   - owner/repository: `feelpp/kub-cli`
+   - workflow: `publish-pypi.yml`
+   - environment: `pypi`
+4. Ensure the first trusted release tag already exists in the repository.
+
+Release steps:
+
+```bash
+# 1) bump version in source tree
+kub-cli bump patch
+
+# 2) commit + tag matching SemVer version
+git add pyproject.toml src/kub_cli/__init__.py
+git commit -m "Release 0.1.1"
+git tag v0.1.1
+git push origin main --tags
+```
+
+The workflow validates the tag format and checks that it matches `pyproject.toml` before building and publishing to PyPI.
 
 ## License
 

--- a/scripts/validate_release_tag.py
+++ b/scripts/validate_release_tag.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 University of Strasbourg
+# SPDX-FileContributor: Christophe Prud'homme
+# SPDX-FileContributor: Cemosis
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate release tag format and match with pyproject version."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import re
+import sys
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised on Python < 3.11
+    import tomli as tomllib
+
+
+SEMVER_PATTERN = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+
+
+def fail(message: str) -> int:
+    print(f"Error: {message}", file=sys.stderr)
+    return 2
+
+
+def normalizeTagValue(rawTag: str) -> str:
+    tagValue = rawTag.strip()
+    if tagValue.startswith("refs/tags/"):
+        tagValue = tagValue[len("refs/tags/") :]
+    return tagValue
+
+
+def extractVersionFromTag(tagValue: str) -> str:
+    normalizedTag = normalizeTagValue(tagValue)
+    if not normalizedTag.startswith("v"):
+        raise ValueError(
+            f"Release tag '{normalizedTag}' must start with 'v' (for example: v0.2.1)."
+        )
+
+    versionValue = normalizedTag[1:]
+    if SEMVER_PATTERN.match(versionValue) is None:
+        raise ValueError(
+            f"Release tag '{normalizedTag}' is not valid SemVer (expected vMAJOR.MINOR.PATCH)."
+        )
+
+    return versionValue
+
+
+def readProjectVersion(pyprojectPath: Path) -> str:
+    if not pyprojectPath.exists():
+        raise ValueError(f"pyproject.toml not found at '{pyprojectPath}'.")
+
+    data = tomllib.loads(pyprojectPath.read_text(encoding="utf-8"))
+    projectTable = data.get("project")
+    if not isinstance(projectTable, dict):
+        raise ValueError("Missing [project] table in pyproject.toml.")
+
+    versionValue = projectTable.get("version")
+    if not isinstance(versionValue, str):
+        raise ValueError("Missing string project.version in pyproject.toml.")
+
+    if SEMVER_PATTERN.match(versionValue.strip()) is None:
+        raise ValueError(
+            f"project.version '{versionValue}' is not SemVer (expected MAJOR.MINOR.PATCH)."
+        )
+
+    return versionValue.strip()
+
+
+def buildParser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate release tag (vMAJOR.MINOR.PATCH) and pyproject version match."
+    )
+    parser.add_argument(
+        "--tag",
+        default=os.environ.get("GITHUB_REF_NAME", ""),
+        help=(
+            "Tag to validate (for example: v0.2.1). "
+            "Defaults to GITHUB_REF_NAME if set."
+        ),
+    )
+    parser.add_argument(
+        "--pyproject",
+        default="pyproject.toml",
+        help="Path to pyproject.toml (default: pyproject.toml).",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = buildParser()
+    args = parser.parse_args()
+
+    tagArg = str(args.tag).strip()
+    if not tagArg:
+        return fail("No tag provided. Pass --tag vMAJOR.MINOR.PATCH.")
+
+    try:
+        tagVersion = extractVersionFromTag(tagArg)
+        projectVersion = readProjectVersion(Path(str(args.pyproject)))
+    except ValueError as error:
+        return fail(str(error))
+
+    if tagVersion != projectVersion:
+        return fail(
+            "Tag version does not match pyproject version: "
+            f"tag={tagVersion}, project.version={projectVersion}."
+        )
+
+    print(f"Validated release tag v{tagVersion} against project.version {projectVersion}.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/kub_cli/cli.py
+++ b/src/kub_cli/cli.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Sequence
 
 import typer
@@ -14,6 +15,7 @@ import typer
 from . import __version__
 from .commands import WrapperOptions, runWrapperCommand
 from .errors import KubCliError
+from .versioning import bumpProjectVersion
 
 
 CONTEXT_SETTINGS = {
@@ -185,6 +187,7 @@ def createMetaApp() -> typer.Typer:
 
     @app.callback(invoke_without_command=True)
     def meta(
+        ctx: typer.Context,
         version: bool = typer.Option(
             False,
             "--version",
@@ -196,9 +199,55 @@ def createMetaApp() -> typer.Typer:
             typer.echo(f"kub-cli {__version__}")
             raise typer.Exit(code=0)
 
-        typer.echo(
-            "kub-cli thin wrapper. Use: kub-dataset, kub-simulate, kub-dashboard, kub-img."
-        )
+        if ctx.invoked_subcommand is None:
+            typer.echo(
+                "kub-cli thin wrapper. Use: kub-dataset, kub-simulate, kub-dashboard, kub-img."
+            )
+
+    @app.command("bump")
+    def bumpCommand(
+        part: str = typer.Argument(
+            "patch",
+            metavar="PART",
+            help="Semantic version part to bump: major, minor, patch.",
+        ),
+        toVersion: str | None = typer.Option(
+            None,
+            "--to",
+            metavar="VERSION",
+            help="Set an explicit semantic version (MAJOR.MINOR.PATCH).",
+        ),
+        projectRoot: Path = typer.Option(
+            Path("."),
+            "--project-root",
+            metavar="PATH",
+            help="Project root containing pyproject.toml.",
+        ),
+        dryRun: bool = typer.Option(
+            False,
+            "--dry-run",
+            help="Print planned version changes without writing files.",
+        ),
+    ) -> None:
+        try:
+            result = bumpProjectVersion(
+                projectRoot=projectRoot.resolve(),
+                part=part,
+                toVersion=toVersion,
+                dryRun=dryRun,
+            )
+        except KubCliError as error:
+            typer.secho(str(error), fg=typer.colors.RED, err=True)
+            raise typer.Exit(code=error.exit_code) from error
+
+        if result.changed:
+            action = "Planned" if dryRun else "Updated"
+            typer.echo(f"{action} version: {result.oldVersion} -> {result.newVersion}")
+        else:
+            typer.echo(f"Version unchanged: {result.newVersion}")
+
+        typer.echo(f"pyproject: {result.pyprojectPath}")
+        typer.echo(f"fallback: {result.initPath}")
 
     return app
 

--- a/src/kub_cli/versioning.py
+++ b/src/kub_cli/versioning.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: 2026 University of Strasbourg
+# SPDX-FileContributor: Christophe Prud'homme
+# SPDX-FileContributor: Cemosis
+# SPDX-License-Identifier: Apache-2.0
+
+"""Version bump utilities for kub-cli development workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+
+from .errors import KubCliError
+
+
+SEMVER_PATTERN = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+PYPROJECT_VERSION_PATTERN = re.compile(
+    r"(^version\s*=\s*\")(\d+\.\d+\.\d+)(\"\s*$)",
+    re.MULTILINE,
+)
+INIT_FALLBACK_VERSION_PATTERN = re.compile(
+    r"(^\s*__version__\s*=\s*\")(\d+\.\d+\.\d+)(\"\s*$)",
+    re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class SemanticVersion:
+    """Semantic version components."""
+
+    major: int
+    minor: int
+    patch: int
+
+    def toString(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+
+@dataclass(frozen=True)
+class BumpResult:
+    """Result of version bump planning/execution."""
+
+    oldVersion: str
+    newVersion: str
+    pyprojectPath: Path
+    initPath: Path
+    changed: bool
+
+
+def parseSemanticVersion(rawValue: str) -> SemanticVersion:
+    normalized = rawValue.strip()
+    match = SEMVER_PATTERN.match(normalized)
+    if match is None:
+        raise KubCliError(
+            f"Invalid version '{rawValue}'. Expected semantic version MAJOR.MINOR.PATCH."
+        )
+
+    return SemanticVersion(
+        major=int(match.group(1)),
+        minor=int(match.group(2)),
+        patch=int(match.group(3)),
+    )
+
+
+def bumpSemanticVersion(currentVersion: SemanticVersion, part: str) -> SemanticVersion:
+    normalizedPart = part.strip().lower()
+
+    if normalizedPart == "major":
+        return SemanticVersion(
+            major=currentVersion.major + 1,
+            minor=0,
+            patch=0,
+        )
+
+    if normalizedPart == "minor":
+        return SemanticVersion(
+            major=currentVersion.major,
+            minor=currentVersion.minor + 1,
+            patch=0,
+        )
+
+    if normalizedPart == "patch":
+        return SemanticVersion(
+            major=currentVersion.major,
+            minor=currentVersion.minor,
+            patch=currentVersion.patch + 1,
+        )
+
+    raise KubCliError(
+        f"Invalid bump part '{part}'. Use one of: major, minor, patch."
+    )
+
+
+def bumpProjectVersion(
+    *,
+    projectRoot: Path,
+    part: str,
+    toVersion: str | None,
+    dryRun: bool,
+) -> BumpResult:
+    pyprojectPath = projectRoot / "pyproject.toml"
+    initPath = projectRoot / "src" / "kub_cli" / "__init__.py"
+
+    oldVersion = readPyprojectVersion(pyprojectPath)
+    oldSemanticVersion = parseSemanticVersion(oldVersion)
+
+    if toVersion is not None:
+        newVersion = parseSemanticVersion(toVersion).toString()
+    else:
+        newVersion = bumpSemanticVersion(oldSemanticVersion, part).toString()
+
+    changed = oldVersion != newVersion
+
+    if not dryRun and changed:
+        replaceVersionInFile(
+            filePath=pyprojectPath,
+            pattern=PYPROJECT_VERSION_PATTERN,
+            newVersion=newVersion,
+            valueLabel="pyproject version",
+        )
+        replaceVersionInFile(
+            filePath=initPath,
+            pattern=INIT_FALLBACK_VERSION_PATTERN,
+            newVersion=newVersion,
+            valueLabel="__init__ fallback version",
+        )
+
+    return BumpResult(
+        oldVersion=oldVersion,
+        newVersion=newVersion,
+        pyprojectPath=pyprojectPath,
+        initPath=initPath,
+        changed=changed,
+    )
+
+
+def readPyprojectVersion(pyprojectPath: Path) -> str:
+    if not pyprojectPath.exists():
+        raise KubCliError(f"pyproject.toml not found at '{pyprojectPath}'.")
+
+    content = pyprojectPath.read_text(encoding="utf-8")
+    match = PYPROJECT_VERSION_PATTERN.search(content)
+
+    if match is None:
+        raise KubCliError(
+            f"Unable to locate project version in '{pyprojectPath}'."
+        )
+
+    return match.group(2)
+
+
+def replaceVersionInFile(
+    *,
+    filePath: Path,
+    pattern: re.Pattern[str],
+    newVersion: str,
+    valueLabel: str,
+) -> None:
+    if not filePath.exists():
+        raise KubCliError(f"Expected file not found: '{filePath}'.")
+
+    content = filePath.read_text(encoding="utf-8")
+
+    def replacement(match: re.Match[str]) -> str:
+        return f"{match.group(1)}{newVersion}{match.group(3)}"
+
+    updatedContent, count = pattern.subn(replacement, content, count=1)
+
+    if count != 1:
+        raise KubCliError(
+            f"Unable to update {valueLabel} in '{filePath}'."
+        )
+
+    filePath.write_text(updatedContent, encoding="utf-8")

--- a/tests/test_release_validation.py
+++ b/tests/test_release_validation.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2026 University of Strasbourg
+# SPDX-FileContributor: Christophe Prud'homme
+# SPDX-FileContributor: Cemosis
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+
+
+def writePyproject(path: Path, versionValue: str) -> None:
+    path.write_text(
+        (
+            "[project]\n"
+            'name = "kub-cli"\n'
+            f'version = "{versionValue}"\n'
+        ),
+        encoding="utf-8",
+    )
+
+
+def scriptPath() -> Path:
+    return Path(__file__).resolve().parents[1] / "scripts" / "validate_release_tag.py"
+
+
+def testValidateReleaseTagSuccess(tmp_path: Path) -> None:
+    pyprojectPath = tmp_path / "pyproject.toml"
+    writePyproject(pyprojectPath, "1.2.3")
+
+    process = subprocess.run(
+        [
+            sys.executable,
+            str(scriptPath()),
+            "--tag",
+            "v1.2.3",
+            "--pyproject",
+            str(pyprojectPath),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert process.returncode == 0
+    assert "Validated release tag v1.2.3" in process.stdout
+
+
+def testValidateReleaseTagRejectsInvalidTag(tmp_path: Path) -> None:
+    pyprojectPath = tmp_path / "pyproject.toml"
+    writePyproject(pyprojectPath, "1.2.3")
+
+    process = subprocess.run(
+        [
+            sys.executable,
+            str(scriptPath()),
+            "--tag",
+            "release-1.2.3",
+            "--pyproject",
+            str(pyprojectPath),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert process.returncode == 2
+    assert "must start with 'v'" in process.stderr
+
+
+def testValidateReleaseTagRejectsVersionMismatch(tmp_path: Path) -> None:
+    pyprojectPath = tmp_path / "pyproject.toml"
+    writePyproject(pyprojectPath, "1.2.3")
+
+    process = subprocess.run(
+        [
+            sys.executable,
+            str(scriptPath()),
+            "--tag",
+            "v1.2.4",
+            "--pyproject",
+            str(pyprojectPath),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert process.returncode == 2
+    assert "Tag version does not match pyproject version" in process.stderr

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: 2026 University of Strasbourg
+# SPDX-FileContributor: Christophe Prud'homme
+# SPDX-FileContributor: Cemosis
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from kub_cli.cli import metaApp
+from kub_cli.errors import KubCliError
+from kub_cli.versioning import bumpProjectVersion
+
+
+@pytest.fixture
+def cliRunner() -> CliRunner:
+    return CliRunner()
+
+
+def writeProjectLayout(projectRoot: Path, versionValue: str) -> None:
+    srcDir = projectRoot / "src" / "kub_cli"
+    srcDir.mkdir(parents=True, exist_ok=True)
+
+    (projectRoot / "pyproject.toml").write_text(
+        (
+            "[project]\n"
+            'name = "kub-cli"\n'
+            f'version = "{versionValue}"\n'
+        ),
+        encoding="utf-8",
+    )
+    (srcDir / "__init__.py").write_text(
+        (
+            '"""kub-cli package."""\n\n'
+            'from importlib.metadata import PackageNotFoundError, version\n\n'
+            "try:\n"
+            '    __version__ = version("kub-cli")\n'
+            "except PackageNotFoundError:\n"
+            f'    __version__ = "{versionValue}"\n'
+        ),
+        encoding="utf-8",
+    )
+
+
+def testBumpProjectVersionPatchUpdatesFiles(tmp_path: Path) -> None:
+    projectRoot = tmp_path / "repo"
+    writeProjectLayout(projectRoot, "1.2.3")
+
+    result = bumpProjectVersion(
+        projectRoot=projectRoot,
+        part="patch",
+        toVersion=None,
+        dryRun=False,
+    )
+
+    assert result.oldVersion == "1.2.3"
+    assert result.newVersion == "1.2.4"
+    assert result.changed is True
+
+    pyprojectContent = (projectRoot / "pyproject.toml").read_text(encoding="utf-8")
+    initContent = (projectRoot / "src" / "kub_cli" / "__init__.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'version = "1.2.4"' in pyprojectContent
+    assert '__version__ = "1.2.4"' in initContent
+
+
+def testBumpProjectVersionDryRunDoesNotWrite(tmp_path: Path) -> None:
+    projectRoot = tmp_path / "repo"
+    writeProjectLayout(projectRoot, "0.9.0")
+
+    result = bumpProjectVersion(
+        projectRoot=projectRoot,
+        part="minor",
+        toVersion=None,
+        dryRun=True,
+    )
+
+    assert result.oldVersion == "0.9.0"
+    assert result.newVersion == "0.10.0"
+    assert result.changed is True
+
+    pyprojectContent = (projectRoot / "pyproject.toml").read_text(encoding="utf-8")
+    initContent = (projectRoot / "src" / "kub_cli" / "__init__.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'version = "0.9.0"' in pyprojectContent
+    assert '__version__ = "0.9.0"' in initContent
+
+
+def testBumpProjectVersionToExplicitValue(tmp_path: Path) -> None:
+    projectRoot = tmp_path / "repo"
+    writeProjectLayout(projectRoot, "2.1.0")
+
+    result = bumpProjectVersion(
+        projectRoot=projectRoot,
+        part="patch",
+        toVersion="2.5.9",
+        dryRun=False,
+    )
+
+    assert result.oldVersion == "2.1.0"
+    assert result.newVersion == "2.5.9"
+
+    pyprojectContent = (projectRoot / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'version = "2.5.9"' in pyprojectContent
+
+
+def testBumpProjectVersionInvalidPartRaises(tmp_path: Path) -> None:
+    projectRoot = tmp_path / "repo"
+    writeProjectLayout(projectRoot, "1.0.0")
+
+    with pytest.raises(KubCliError, match="Invalid bump part"):
+        bumpProjectVersion(
+            projectRoot=projectRoot,
+            part="build",
+            toVersion=None,
+            dryRun=False,
+        )
+
+
+def testMetaBumpCommandUpdatesVersion(cliRunner: CliRunner, tmp_path: Path) -> None:
+    projectRoot = tmp_path / "repo"
+    writeProjectLayout(projectRoot, "3.0.1")
+
+    result = cliRunner.invoke(
+        metaApp,
+        ["bump", "minor", "--project-root", str(projectRoot)],
+    )
+
+    assert result.exit_code == 0
+    assert "Updated version: 3.0.1 -> 3.1.0" in result.stdout
+    assert "kub-cli thin wrapper" not in result.stdout
+
+    pyprojectContent = (projectRoot / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'version = "3.1.0"' in pyprojectContent
+
+
+def testMetaBumpCommandDryRun(cliRunner: CliRunner, tmp_path: Path) -> None:
+    projectRoot = tmp_path / "repo"
+    writeProjectLayout(projectRoot, "4.4.4")
+
+    result = cliRunner.invoke(
+        metaApp,
+        ["bump", "patch", "--project-root", str(projectRoot), "--dry-run"],
+    )
+
+    assert result.exit_code == 0
+    assert "Planned version: 4.4.4 -> 4.4.5" in result.stdout
+
+    pyprojectContent = (projectRoot / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'version = "4.4.4"' in pyprojectContent


### PR DESCRIPTION
- Introduced GitHub Actions workflow for publishing to PyPI on version tags.
- Added `kub-cli bump` command for semantic version updates in `pyproject.toml`.
- Implemented release validation script to enforce version tag format.
- Updated documentation to reflect new versioning and publishing processes.
- Added tests for release tag validation and version bumping functionality.

- closes #1 